### PR TITLE
Typos etc in Unfinished Business

### DIFF
--- a/Unfinished Business.md
+++ b/Unfinished Business.md
@@ -13,19 +13,19 @@ Unfinished Business is a small "dungeon" intended as a short intro adventure for
 
 Ghosts of a long since dead Executive Board of Thaumaturgic Solutions Inc., have unfinished business. Literally. Contracts require them to deliver a product before they can move on.
 
-They have terapped Velma Cranberry (along with a number of other living and undead beings) in exploitative contracts which force them to try and accomplish TSI's unrealistic goals.
+They have trapped Velma Cranberry (along with a number of other living and undead beings) in exploitative contracts, which force them to try and accomplish TSI's unrealistic goals.
 
 ## Hook (Context for the Players)
 
-You have been hired by a relative of Velma Cranberry, a recent graduate of Wizard Poly-Magic Tech University. After receiving a job offer from TSI she has dropped out of contact and her friends and family are concerned. You’ve been given the location of TSI HQ, and are tasked with bringing her to safety.
+You have been hired by a relative of Velma Cranberry, a recent graduate of Wizard Poly-Magic Tech University. After receiving a job offer from TSI, she has dropped out of contact, and her friends and family are concerned. You've been given the location of TSI HQ, and are tasked with bringing her to safety.
 
 ## Encounter Table (d6)
 
 Using the [Encounter Roll](/Running/DungeonCrawling) rules.
 
-1. **Unpaid Intern** - Scurrying around carrying documents, cups of coffee, or on random errands for the Board. Not-hostile to players under any circumstances.
+1. **Unpaid Intern** - Scurrying around carrying documents, cups of coffee, or on random errands for the Board. Not hostile to players under any circumstances.
 2. **Skeleton Staff** - Raised from the Hiring Pool, resentful of the company. Will attempt to help the players to the extent that their contract allows. 
-3. **Skeleton Staff** - Raised from the Hiring Pool, true believer of the company. Will attempt to subdue the players or call in a Security Zombie.
+3. **Skeleton Staff** - Raised from the Hiring Pool, a true believer of the company. Will attempt to subdue the players or call in a Security Zombie.
 4. **Security Zombie** - Zombie raised from the Hiring Pool. Attacks anyone without a Visitor's Badge.
 5. 1d4 **Security Zombies** - Zombies raised from the Hiring Pool. Attack anyone without a Visitor's Badge.
 6. **Head Hunter** -  Dullahan recruiter who will drag talented prospects to the Hiring Pool.
@@ -36,20 +36,20 @@ Using the [Encounter Roll](/Running/DungeonCrawling) rules.
 
 *Map by Evlyn Moreau*
 
-The interior of TSI has the appearance of a modern corporate building, but rendered in damp, dank dungeon stone. It is all well lit, with magical lighting tubes affixe to the ceiling. Every the trappings of modern office buildings are found embedded in the setting of a classic fantasy dungeon.
+The interior of TSI has the appearance of a modern corporate building but rendered in damp, dank dungeon stone. It is all well-lit, with magical lighting tubes affixed to the ceiling. All the trappings of a modern office building are found embedded in the setting of a classic fantasy dungeon.
 
 ### Entrance
 
-The entrance to Thaumatergic Solutions Inc. is a large, open archway carved into the side of a cliff. The company's name is carved into the wall above the door in crisp, clean lettering and white light shines up the steps leading down into the company. 
+The entrance to Thaumatergic Solutions Inc. is a large, open archway carved into the side of a cliff. The company's name is carved into the wall above the door in crisp, clean lettering, and white light shines up the steps leading down into the company. 
 
 
-###	1. Entrance Hall
+### 1. Entrance Hall
 
-**Reception desk** staffed by **Skeleton Receptionist** who will give Visitor Badges if an NDA is signed. The NDA is a magical contract that will wipe the signers memories upon leaving TSI unless the contracts are ended or the singers are otherwise freed. 
+**Reception desk** staffed by **Skeleton Receptionist** who will give Visitor Badges if an NDA is signed. The NDA is a magical contract that will wipe the signers' memories upon leaving TSI unless the contracts are ended, or the signers are otherwise freed. 
 
 ### 2. Board Room
 
-The **Board** surrounds a long, glossy table as a mass of souls merged into vague corporate intent. An **Intern** furiously takes notes on their unceasing buzz-word laden murmuring.
+The **Board** surrounds a long, glossy table as a mass of souls merged into vague corporate intent. An **Intern** furiously takes notes on their unceasing buzz-word-laden murmuring.
 
 If a player seems talented, they will call a Head Hunter to "hire" them. If the players are disruptive, they will call Security Guards to remove them.
 
@@ -63,39 +63,39 @@ Falling in deals 1 Critical Damage per round. Death causes flesh to be stripped 
 
 A **djinn** named "X'eer Oxx" is bound within a **glowing blue cube** and forced to make copies for the Company. An **Intern** is currently Z'eer Oxx-ing a stack of documents.
 
-Simple, mundane objects placed on the cube’s surface are copied perfectly in a bright white flash. Complex *or* magical objects produce [fragile](/Callings/Artificer.html#core-ability---walking-workshop) copies. Copies of living, or complex *and* magical, objects will fail violently and horribly when copied.
+Simple, mundane objects placed on the cube's surface are copied perfectly in a bright white flash. Complex *or* magical objects produce [fragile](/Callings/Artificer.html#core-ability---walking-workshop) copies. Copies of living, or complex *and* magical, objects will fail violently and horribly when copied.
 
 ### 5. Workshop
 
-A **desk** covered in a mess of technical documents and sorcererous scrolls hugs one wall, an **unmade cot** hugs another. A large **arcane circle** engraved into the floor surrounds a huge, complex looking **suit of armor**.
+A **desk** covered in a mess of technical documents and sorcerous scrolls hugs one wall, and an **unmade cot** hugs another. A large **arcane circle** engraved into the floor surrounds a huge, complex looking **suit of armor**.
 
-**Velma** is currently scribbling notes at the desk. She’s frazzled, low on sleep, and living exclusively off of [Herb's Interplanar Delivery](/Rituals) from her meager paycheck (she is paid mostly in stocks).
+**Velma** is currently scribbling notes at the desk. She's frazzled, low on sleep, and living exclusively off of [Herb's Interplanar Delivery](/Rituals) from her meager paycheck (she is paid mostly in stocks).
 
-She wants to leave, but her Contract forces her to continue working on the project. If the players can provide a halfway plausible plan, she will make the Power Armor functional, although the power source will only last for a single 10 minute Turn.
+She wants to leave, but her Contract forces her to continue working on the project. If the players can provide a halfway plausible plan, she will make the Power Armor functional, although the power source will only last for a single 10-minute Turn.
 
-**Power Armor** - +2 Armor while powered, immobile while not. Spend 2 minutes worth of power to peform a dramatic powered action (power fist, power blast, power charge, etc.). Startup sequence requires the wearer to sign over rights to their likeness, 25% of all earned loot, and all generated Bardic Tales of their exploits.
+**Power Armor** - +2 Armor while powered, immobile while not. Spend 2 minutes worth of power to perform a dramatic powered action (power fist, power blast, power charge, etc.). The startup sequence requires the wearer to sign over rights to their likeness, 25% of all earned loot, and all generated Bardic Tales of their exploits.
 
-### 6. Founder’s Rest
+### 6. Founder's Rest
 
-A **sarcophagus** sits in center of room, surrounded by **cold mist** flowing out of the lid. A **Trophy Case** covers the north wall, filled with various corporate and marketing awards. All are polished but one, and if the unpolished award is moved a secret door to 7 is opened.
+A **sarcophagus** sits in the center of the room, surrounded by **cold mist** flowing out of the lid. A **Trophy Case** covers the north wall, filled with various corporate and marketing awards. All are polished but one, and if the unpolished award is moved, a secret door to 7 is opened.
 
-Two **Zombie Security Guards** stand at watch, preventing anyone from touching the sarcophagus or the trophy case. Magical sight or investigation reveals an ethereal soul cord running from the sarcophagus to 7 (connects to the Chain Block).
+Two **Zombie Security Guards** stand watch, preventing anyone from touching the sarcophagus or the trophy case. Magical sight or investigation reveals an ethereal soul cord running from the sarcophagus to 7 (connects to the Chain Block).
 
-Each time the sarcophagus or trophy case is touched, or a loud noise is made, there is a 3 in 6 chance the Founder awakens from his semi-retirement.The Founder will attempt to subdue (and then hire via the Hiring Pool) any interlopers once awoken.
+Each time the sarcophagus or trophy case is touched or a loud noise is made, there is a 3 in 6 chance the Founder awakens from his semi-retirement. The Founder will attempt to subdue (and then hire via the Hiring Pool) any interlopers once awoken.
 
 ### 7. Secret Storage Room
 
 Filled with chests and filing cabinets containing:
 
-* 1d6 **Pink Slips**: Use to “fire” a Security Guard or Head Hunter. If shown both the slip and the target will evaporate instantly.
+* 1d6 **Pink Slips**: Use to "fire" a Security Guard or Head Hunter. If shown, both the slip and the target will evaporate instantly.
 * 3d6x100 **Anti-Coins** - Ghostly, pale blue coins representing *debt*. Cannot be dropped. Instantly annihilate 1 to 1 with any owned normal Coins. 
-* **The Chain Block** - A tighly packed brick of welded chain. Contains the Founder's Soul. The Founder cannot permanently die while this is intact. If the Founder's soul is removed, the Chain Block can be used to bind non-corporeal entities.
+* **The Chain Block** - A tightly packed brick of welded chain. Contains the Founder's Soul. The Founder cannot permanently die while this is intact. If the Founder's soul is removed, the Chain Block can be used to bind non-corporeal entities.
 * The Company's **Charters & Contracts**:
-	* The Company is dissolved & all contracts ended if the Founder is no longer with the company (Founder must be fully killed or forced to activate his Golden Parachute for this to be true).
-	* The Development Contract to create the Gig Adventure Suit can be completed by a certified third party company declaring the product acceptable.
-	* Velma Cranberry's Contract: A loophole means she can be freed from her contract by accumulating 3 demerits for refusing to follow the Founder's Company Policies. 
-	* If an Intern is given any amount of money their contract is immediately ended and they are magically ejected from the premises (to avoid obligations of health care or benefits to actual employees).
-	* X'eer Oxx's binding wish as a notarized document. Loophole: The djinn *must* copy all documents, but *cannot* duplicate wishes. Attempt to copy the the wish document on his cube to break him free.
+  * The Company is dissolved & all contracts end if the Founder is no longer with the company (Founder must be fully killed or forced to activate his Golden Parachute for this to be true).
+  * The Development Contract to create the Gig Adventure Suit can be completed by a certified third-party company declaring the product acceptable.
+  * Velma Cranberry's Contract: A loophole means she can be freed from her contract by accumulating 3 demerits for refusing to follow the Founder's Company Policies. 
+  * If an Intern is given any amount of money, their contract is immediately ended, and they are magically ejected from the premises (to avoid obligations of health care or benefits to actual employees).
+  * X'eer Oxx's binding wish as a notarized document. Loophole: The djinn *must* copy all documents but *cannot* duplicate wishes. Attempt to copy the wish document on his cube to break him free.
 
 ## Bestiary
 
@@ -104,15 +104,15 @@ Filled with chests and filing cabinets containing:
 1 Grit, d4 STR, d4 DEX, d4 WIL, Hot-Coffee (d8, single use)
 
 * Wears an Intern badge (with portrait) on a lanyard around their neck.
-* Lives in both hope and fear they will be made full emploees via the Hiring Pool (and turned into a Skeleton or Zombie).
+* Lives in both hope and fear they will be made full employees via the Hiring Pool (and turned into a Skeleton or Zombie).
 * Usually scurrying between rooms with documents or coffee.
 
 ### Skeleton Employee
 
 3 Grit, d6 STR, d6 DEX, d6 WIL,  (d6)
 
-* 3 in 6 chance they are disillusioned with TSI and will assist players to the extend their Contract allows.
-* Otherwise they are true believers, and will attempt to apprehend the players or call a Zombie Guard.
+* 3 in 6 chance, they are disillusioned with TSI and will assist players to the extent their Contract allows.
+* Otherwise they are true believers and will attempt to apprehend the players or call a Zombie Guard.
 
 ### Zombie Security Guard
 
@@ -133,7 +133,7 @@ Filled with chests and filing cabinets containing:
 
 * Critical Damage with Hostile Takeover: The Board puppets the target (forcing them to attack their party members) until they succeed at a WIL Save. Can only puppet one target at a time.
 * *Incorporeal*, unable to be harmed except by magic or silver weapons.
-* If killed they will reform in 1d4 Turns so long as their Development Contract is unresolved.
+* If killed, they will reform in 1d4 Turns so long as their Development Contract is unresolved.
 
 ### The Founder
 
@@ -147,6 +147,6 @@ Filled with chests and filing cabinets containing:
 Company Policy (1d4):
 
 1. Ice Breaker Event! Share your work experience and a fun fact about yourself prior to any actions.
-2. Casual Friday! Everyone must be wearing at least one “fun” article of clothing.
-3. Wellness Wednesday! To prevent injury it is prohibited to carry more than one *bulky* item.
+2. Casual Friday! Everyone must be wearing at least one "fun" article of clothing.
+3. Wellness Wednesday! To prevent injury, it is prohibited to carry more than one *bulky* item.
 5. Re-Org! Each player is randomly assigned another player as their manager. All actions must receive verbal or written permission from a manager.


### PR DESCRIPTION
A grammar and comma pass, also normalized your quotes to straight, since Markdown usually does it own 'curling'.